### PR TITLE
Fixes/refractors

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "develop": "concurrently \"cd server && npm run watch\" \"cd client && npm run dev\"",
     "install": "cd server && npm i && cd ../client && npm i",
     "seed": "cd server && npm run seed",
-    "build": "cd client && npm run build"
+    "build": "cd client && npm run build",
+    "example": "node server/utils/cartQL/test.js"
   },
   "keywords": [],
   "author": "",

--- a/server/seeds/seed.js
+++ b/server/seeds/seed.js
@@ -16,10 +16,11 @@ connection.once('open', async () => {
 
     await Food.insertMany(foodData);
     await User.insertMany(userData);
+
+    console.log('Food & User Data seeded!');
   } catch (err) {
     console.log("Failed");
   }
 
-  console.log('Food & User Data seeded!');
   process.exit(0);
 });

--- a/server/utils/cartQL/index.js
+++ b/server/utils/cartQL/index.js
@@ -30,7 +30,7 @@ async function queryCartQL(fnQuery, variables) {
       throw new Error('graphQL error');
     }
 
-    return data;
+    return data.data;
   } catch (err) {
     console.log(err);
     return null;

--- a/server/utils/cartQL/mutations.js
+++ b/server/utils/cartQL/mutations.js
@@ -4,10 +4,11 @@ module.exports = {
       mutation {
         addItem(
           input: {
-            cartId: "${a.user.cart}"
+            cartId: "${a.user._id}"
             id: "${a.food._id}"
             name: "${a.food.name}"
             price: ${a.food.price}
+            quantity: ${a.quantity || 1}
           }
         ) {
           id
@@ -40,7 +41,7 @@ module.exports = {
       mutation {
         removeItem(
           input: {
-            cartId: "${a.user.cart}"
+            cartId: "${a.user._id}"
             id: "${a.food._id}"
           }
         ) {
@@ -69,12 +70,13 @@ module.exports = {
       }
     `;
   },
+
   updateCartItem(a) {
     return `
       mutation {
         updateItem(
           input: {
-            cartId: "${a.user.cart}"
+            cartId: "${a.user._id}"
             id: "${a.food._id}"
             quantity: ${a.quantity}
           }
@@ -104,12 +106,13 @@ module.exports = {
       }
     `;
   },
+
   cartCheckout(a) {
     return `
   mutation {
     checkout(
       input: {
-        cartId: "${a.user.cart}"
+        cartId: "${a.user._id}"
         email: "bob@bob.com"
         shipping: {
           name: "Bob"

--- a/server/utils/cartQL/mutations.js
+++ b/server/utils/cartQL/mutations.js
@@ -109,36 +109,36 @@ module.exports = {
 
   cartCheckout(a) {
     return `
-  mutation {
-    checkout(
-      input: {
-        cartId: "${a.user._id}"
-        email: "bob@bob.com"
-        shipping: {
-          name: "Bob"
-          line1: "123 Anywhere Lane"
-          city: "Brooklyn"
-          postalCode: "95255"
-          country: "USA"
-        }
-        }
-    ) {
-      id
-      items {
-        id
-        name
-        quantity
-        lineTotal {
-          amount
-          formatted
+      mutation {
+        checkout(
+          input: {
+            cartId: "${a.id}"
+            email: "bob@bob.com"
+            shipping: {
+              name: "Bob"
+              line1: "123 Anywhere Lane"
+              city: "Brooklyn"
+              postalCode: "95255"
+              country: "USA"
+            }
+          }
+        ) {
+          id
+          items {
+            id
+            name
+            quantity
+            lineTotal {
+              amount
+              formatted
+            }
+          }
+          grandTotal {
+            amount
+            formatted
+          }
         }
       }
-      grandTotal {
-        amount
-        formatted
-      }
-  }
-}
-  `;
+    `;
   },
 };

--- a/server/utils/cartQL/queries.js
+++ b/server/utils/cartQL/queries.js
@@ -1,11 +1,13 @@
 module.exports = {
-  queryCart(a) {
+  queryCart({ id }) {
     return `
       query {
-        cart(id: "${a.user._id}" ) {
+        cart(id: "${id}" ) {
           id
           isEmpty
           totalItems
+          totalUniqueItems
+          abandoned
           items {
             id
             name

--- a/server/utils/cartQL/queries.js
+++ b/server/utils/cartQL/queries.js
@@ -1,8 +1,8 @@
 module.exports = {
-  queryCart({id}) {
+  queryCart(a) {
     return `
       query {
-        cart(id: "${id}" ) {
+        cart(id: "${a.user._id}" ) {
           id
           isEmpty
           totalItems

--- a/server/utils/cartQL/test.js
+++ b/server/utils/cartQL/test.js
@@ -1,9 +1,9 @@
 const { CartQueries, CartMutation, queryCartQL} = require('./index');
 
-const args = { user: { _id: "565jsskcjsd833271" }};
+const args = { id: "565jsskcjsd833271" };
 
 const argsAddMango = { 
-  user: { _id: args.user._id},
+  user: { _id: args.id},
   food: {
     _id: "12948612847",
     name: "mango",
@@ -13,7 +13,7 @@ const argsAddMango = {
 };
 
 const argsAddTaco = { 
-  user: { _id: args.user._id},
+  user: { _id: args.id},
   food: {
     _id: "12948612849",
     name: "taco",
@@ -23,7 +23,7 @@ const argsAddTaco = {
 };
 
 const argsUpdateMango = { 
-  user: { _id: args.user._id},
+  user: { _id: args.id},
   food: {
     _id: "12948612847",
     name: "mango",

--- a/server/utils/cartQL/test.js
+++ b/server/utils/cartQL/test.js
@@ -1,9 +1,9 @@
 const { CartQueries, CartMutation, queryCartQL} = require('./index');
 
-const args = { id: "565jkcjsd833271" };
+const args = { user: { _id: "565jsskcjsd833271" }};
 
 const argsAddMango = { 
-  user: { cart: args.id},
+  user: { _id: args.user._id},
   food: {
     _id: "12948612847",
     name: "mango",
@@ -13,7 +13,7 @@ const argsAddMango = {
 };
 
 const argsAddTaco = { 
-  user: { cart: args.id},
+  user: { _id: args.user._id},
   food: {
     _id: "12948612849",
     name: "taco",
@@ -22,29 +22,38 @@ const argsAddTaco = {
   quantity: 5,
 };
 
+const argsUpdateMango = { 
+  user: { _id: args.user._id},
+  food: {
+    _id: "12948612847",
+    name: "mango",
+    price: 450,
+  },
+  quantity: 7,
+};
 
 ;(async function () {
   console.log("\nqueryCart")
   const cart = await queryCartQL(CartQueries.queryCart, args); 
   console.log(require("util").inspect(cart, { depth: null }));
 
-  console.log("\naddCartItem mango")
+  console.log("\naddCartItem mango 10")
   let updatedCart = await queryCartQL(CartMutation.addCartItem, argsAddMango);
   console.log(require("util").inspect(updatedCart, { depth: null }));
 
-  console.log("\naddCartItem taco")
+  console.log("\naddCartItem taco 5")
   updatedCart = await queryCartQL(CartMutation.addCartItem, argsAddTaco);
   console.log(require("util").inspect(updatedCart, { depth: null }));
 
-  console.log("\nupdateCartItem mango")
-  updatedCart = await queryCartQL(CartMutation.updateCartItem, argsAddMango);
+  console.log("\nupdateCartItem mango 7")
+  updatedCart = await queryCartQL(CartMutation.updateCartItem, argsUpdateMango);
   console.log(require("util").inspect(updatedCart, { depth: null }));
 
-  console.log("\nremoveCartItem mango")
-  updatedCart = await queryCartQL(CartMutation.removeCartItem, argsAddMango);
+  console.log("\nremoveCartItem taco")
+  updatedCart = await queryCartQL(CartMutation.removeCartItem, argsAddTaco);
   console.log(require("util").inspect(updatedCart, { depth: null }));
 
   console.log("\ncartCheckout")
-  updatedCart = await queryCartQL(CartMutation.cartCheckout, argsAddMango);
+  updatedCart = await queryCartQL(CartMutation.cartCheckout, args);
   console.log(require("util").inspect(updatedCart, { depth: null }));
 })()


### PR DESCRIPTION
chore: Misc changes
- added 'npm run example' to root dir to see an example of  a cart
- moved the 'success' message when seeding inside the try catch block
- correctly return the cart data from queryCartQL function
 
refactor: Update cartQL mutations and queries
- Change user.cart to user._id
  we're now using user._id as the cart id
- Update the test example to use the new data

fix: Data in the test.js

- Correct the mock args in the example test
- Reverted the changes to query user
- Update checkout mutation to use a.id